### PR TITLE
Changed file write mode from w to wb

### DIFF
--- a/merge_ics/merge_ics.py
+++ b/merge_ics/merge_ics.py
@@ -44,7 +44,7 @@ def write_calendar(options, sources, filename):
         event_copy = Event(event)
         event_copy.add('categories', category)
         cal.add_component(event_copy)
-    with open(filename, 'w') as f:
+    with open(filename, 'wb') as f:
         f.write(cal.to_ical())
 
 


### PR DESCRIPTION
I was getting the `TypeError: write() argument must be str, not bytes` error while trying to concatenate 2 ics files, changed the access mode to `wb`, that has helped.